### PR TITLE
CLI Registrator now dynamically reads all modules in core.filters

### DIFF
--- a/examples/cli_checks_performance.py
+++ b/examples/cli_checks_performance.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, division, print_function
+
+from timeit import timeit
+
+
+def multiple(files):
+    # specify the checks to remove specific files
+    checks = [
+        lambda x: '.py' in x,  # removes all files that DON'T have .py in the name
+        lambda x: '.pyc' not in x,  # removes all files that DO have .pyc in the name
+        lambda x: '__init__' not in x,  # removes all files that DO have __init__ in the name
+        lambda x: 'cli_registrator.py' not in x  # removes all files that have this module's name in the name
+    ]
+
+    for check in checks:
+        files = filter(check, files)
+
+
+def single(files):
+    files = filter(
+        lambda filename: '.py' in filename and '.pyc' not in filename and '__init__' not in filename and 'cli_registrator.py' not in filename,
+        files)
+
+
+if __name__ == '__main__':
+    files = [
+        "some_file.pyc", "some_other_file.py", "what_the_fuck_are_you.md",
+        "__init__.py"
+    ] * 100
+
+    print("Timing in a single statement", timeit(
+        "multiple(files)",
+        "from __main__ import files, multiple",
+        number=100000))
+
+    print("Timing with separate statements", timeit(
+        "single(files)", "from __main__ import files, single", number=100000))

--- a/isis_imaging/core/algorithms/cli_registrator.py
+++ b/isis_imaging/core/algorithms/cli_registrator.py
@@ -1,0 +1,63 @@
+from __future__ import (absolute_import, division, print_function)
+import importlib
+import os
+import warnings
+
+
+def register_into(parser, directory="core/filters"):
+    """
+    This function will import all the filters, and then call
+    cli_register(parser) on them.
+
+    The functionality has been extended to walk the core.filters.* directories automatically and pick up all .py files,
+    and try to register them.
+
+    An alternative implementation for the lambda checks is in examples/cli_checks_performance.py
+    The current implementation was found to be faster, and more readible
+
+    :param parser: the parser into which the modules will be registered
+    :param directory: The directory to be walked for python modules. 
+                      This parameter is currently being added to ease unit testing.
+    """
+    # if user provided files, don't walk anywhere, but run the rest
+
+    all_files = os.walk(directory)
+
+    for root, dirs, files in all_files:
+        # replace the / with . to match python package syntax
+        package_dir = root.replace('/', '.')
+
+        # specify the checks to remove specific files
+        checks = [
+            lambda x: '.py' in x,  # removes all files that DON'T have .py in the name
+            lambda x: '.pyc' not in x,  # removes all files that DO have .pyc in the name
+            lambda x: '__init__' not in x,  # removes all files that DO have __init__ in the name
+            lambda x: 'cli_registrator.py' not in x  # removes all files that have this module's name in the name
+        ]
+
+        # apply all of the above checks
+        for check in checks:
+            files = filter(check, files)
+
+        # trim the .py in the name to get only the filename
+        actual_python_modules = map(lambda x: x[:-3], files)
+
+        # this will make the group name equal the package
+        # this means the core.filters will be separate from
+        # core.filters.wip or any other additional folders
+        group = parser.add_argument_group(package_dir)
+
+        # we specify the full absolute path and append the package name
+        # the code underneath does import core.filters.package_name
+        for module in actual_python_modules:
+            full_module = package_dir + '.' + module
+            m = importlib.import_module(full_module)
+
+            # warn the user if one of the modules is missing the cli_register method
+            try:
+                m.cli_register(group)
+            except AttributeError:
+                cli_register_warning = "The module " + full_module + " does NOT have a cli_register(parser) method!"
+                warnings.warn(cli_register_warning)
+
+    return parser

--- a/isis_imaging/core/configs/recon_config.py
+++ b/isis_imaging/core/configs/recon_config.py
@@ -25,8 +25,7 @@ def grab_full_config():
     parser = functional_args.setup_parser(parser)
 
     # setup args for the filters
-    grp_filters = parser.add_argument_group("Filter options")
-    cli_registrator.register_into(grp_filters)
+    cli_registrator.register_into(parser)
 
     # parse the real arguments
     args = parser.parse_args()

--- a/isis_imaging/core/filters/cli_registrator.py
+++ b/isis_imaging/core/filters/cli_registrator.py
@@ -1,23 +1,57 @@
 from __future__ import (absolute_import, division, print_function)
 import importlib
+import os
+import warnings
 
 
 def register_into(parser):
     """
     This function will import all the filters, and then call
     cli_register(parser) on them.
-    """
-    MODULES = [
-        'circular_mask', 'crop_coords', 'cut_off', 'gaussian', 'median_filter',
-        'minus_log', 'contrast_normalisation', 'background_correction',
-        'outliers', 'rebin', 'rotate_stack', 'ring_removal', 'stripe_removal',
-        'value_scaling', 'clip_values'
-    ]
 
-    for m in MODULES:
+    The functionality has been extended to walk the core.filters.* directories automatically and pick up all .py files,
+    and try to register them.
+
+    An alternative implementation for the lambda checks is in examples/cli_checks_performance.py
+    The current implementation was found to be faster, and more readible
+    """
+    all_files = os.walk("core/filters")
+
+    for root, dirs, files in all_files:
+        # replace the / with . to match python package syntax
+        package_dir = root.replace('/', '.')
+
+        # specify the checks to remove specific files
+        checks = [
+            lambda x: '.py' in x,  # removes all files that DON'T have .py in the name
+            lambda x: '.pyc' not in x,  # removes all files that DO have .pyc in the name
+            lambda x: '__init__' not in x,  # removes all files that DO have __init__ in the name
+            lambda x: 'cli_registrator.py' not in x  # removes all files that have this module's name in the name
+        ]
+
+        # apply all of the above checks
+        for check in checks:
+            files = filter(check, files)
+
+        # trim the .py in the name to get only the filename
+        actual_python_modules = map(lambda x: x[:-3], files)
+
+        # this will make the group name equal the package
+        # this means the core.filters will be separate from
+        # core.filters.wip or any other additional folders
+        group = parser.add_argument_group(package_dir)
+
         # we specify the full absolute path and append the package name
         # the code underneath does import core.filters.package_name
-        m = importlib.import_module('core.filters.' + m)
-        m.cli_register(parser)
+        for module in actual_python_modules:
+            full_module = package_dir + '.' + module
+            m = importlib.import_module(full_module)
+
+            # warn the user if one of the modules is missing the cli_register method
+            try:
+                m.cli_register(group)
+            except AttributeError:
+                cli_register_warning = "The module " + full_module + " does NOT have a cli_register(parser) method!"
+                warnings.warn(cli_register_warning)
 
     return parser

--- a/isis_imaging/core/imgdata/loader.py
+++ b/isis_imaging/core/imgdata/loader.py
@@ -1,4 +1,7 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+import glob
+import os
 
 import numpy as np
 
@@ -206,8 +209,6 @@ def get_file_names(path, img_format, prefix=''):
     :param prefix: A specific prefix for the images
     :return: All the file names, sorted by ascending
     """
-    import os
-    import glob
 
     path = os.path.abspath(os.path.expanduser(path))
 


### PR DESCRIPTION
It walks the directory, picking up _all_ files. Then the ones that are not necessary are removed.

Then it tries to import and run `module_name.cli_register(parser)`, if the call fails, a warning is emitted to the user.